### PR TITLE
Bypass busy mount

### DIFF
--- a/installer/install
+++ b/installer/install
@@ -132,6 +132,9 @@ function is_old_gl() {
 } # To detect whether to revert `GL>6.3` patches
 
 function mount_osroot() {
+        rm -rf /dev/gearblock
+        mkdir /dev/gearblock
+        ln -s /dev/block/* /dev/gearblock
 	geco "\n\n ------- Partition Table -------\n"
 	blkid -s LABEL -s TYPE | grep -v loop | grep -v "/sr" | nl -s "]. " | awk 'NF'
 	while true; do
@@ -142,7 +145,7 @@ function mount_osroot() {
 			geco "\n+ Trying to mount it ..."; ckdirex /mnt 755
 			VAR_OROOT="$(blkid -s LABEL -s TYPE | grep -v loop | grep -v "/sr" | awk 'NF' | sed -n "$c p" 2>/dev/null | cut -d : -f1)"; export GMOUNT="/mnt/gmount"
 			ckdirex "$GMOUNT" 777
-			
+			VAR_OROOT="/dev/gearblock/$(basename "$VAR_OROOT")"
 				case $(blkid "$VAR_OROOT") in
 				*TYPE=*ntfs*)
 	#                     ntfsfix "$VAR_OROOT" > /dev/null 2>&1


### PR DESCRIPTION
When a device block is mounted in a directory, there is a chance that GearLock will fail to mount it in other folder. So we must do trick to bypass in this case