### PR TITLE
fix: sync disks before poweroff/reboot in recovery mode

### DIFF
--- a/bin/gearinit
+++ b/bin/gearinit
@@ -51,6 +51,9 @@ function load_dri(){
 }
 
 function gpower(){
+	# sync disks first
+	echo s > /proc/sysrq-trigger 
+	
 	if [ "$1" = "poweroff" ]; then
 		echo o > /proc/sysrq-trigger
 	elif [ "$1" = "reboot" ]; then


### PR DESCRIPTION
Sometimes, when user does some work in recovery mode -> virtual command terminal (copying some files to /system for example) and immediately uses reboot option without running sync beforehand, changes are not written to disk. Attempt to reduce risk of data loss by syncing disks first. 